### PR TITLE
update templates for compatibility with new datetime structure

### DIFF
--- a/templates/email/officepoliceoversight/complaint/form-data.html
+++ b/templates/email/officepoliceoversight/complaint/form-data.html
@@ -13,7 +13,7 @@
 
         <div class='form-data-section_item'>
           <span>{{t('date_and_time')}}:</span>
-          <p>{{data['datetime'] or 'N/A' }}</p>
+          <p>{{data['datetime']['date']}} {{data['datetime']['time']}}</p>
         </div>
 
         <div class='form-data-section_item'>

--- a/templates/email/officepoliceoversight/complaint/form-data.txt
+++ b/templates/email/officepoliceoversight/complaint/form-data.txt
@@ -23,7 +23,7 @@
 
 
 {{t('date_and_time')}}:
-{{data['datetime'] or 'N/A' }}
+{{data['datetime']['date']}} {{data['datetime']['time']}}
 
 
 

--- a/templates/email/officepoliceoversight/thanks/form-data.html
+++ b/templates/email/officepoliceoversight/thanks/form-data.html
@@ -13,9 +13,8 @@
 
         <div class='form-data-section_item'>
           <span>{{t('date_and_time')}}:</span>
-          <p>{{data['datetime'] or 'N/A' }}</p>
+          <p>{{data['datetime']['date'] or 'N/A'}} {{data['datetime']['time'] or ''}}</p>
         </div>
-
         <div class='form-data-section_item'>
           <span>{{t('has_ticket')}}:</span>
           <p>{{data['hasTicket'] or 'N/A' }}</p>

--- a/templates/email/officepoliceoversight/thanks/form-data.txt
+++ b/templates/email/officepoliceoversight/thanks/form-data.txt
@@ -23,7 +23,7 @@
 
 
 {{t('date_and_time')}}:
-{{data['datetime'] or 'N/A' }}
+{{data['datetime']['date'] or 'N/A'}} {{data['datetime']['time'] or ''}}
 
 
 


### PR DESCRIPTION
https://github.com/cityofaustin/techstack/issues/1446

Related Frontend PR: https://github.com/cityofaustin/officer-form-chapters/pull/13

`datetime: "2019-03-12 09:30 PM"` has been transformed into `datetime: {date: "2019-03-12", time: "09:30 PM"}`. Email template changes worked during my test:

<img width="342" alt="Screen Shot 2019-03-18 at 6 02 04 PM" src="https://user-images.githubusercontent.com/14187277/54570395-51609f00-49ac-11e9-89bf-e2caaabf6783.png">
